### PR TITLE
feature(Core): add printer

### DIFF
--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/LanguageParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/LanguageParser.java
@@ -7,6 +7,7 @@ import edu.kit.kastel.sdq.case4lang.refactorlizar.core.javaparser.ModelBuilder;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser.BundleParser;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.Bundle;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.Component;
+import edu.kit.kastel.sdq.case4lang.refactorlizar.model.ModularLanguage;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,7 +18,7 @@ import spoon.reflect.declaration.CtPackage;
 public class LanguageParser {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-    public static Set<Component> parseLanguage(String path) {
+    public static ModularLanguage parseLanguage(String path) {
         Collection<CtPackage> javaPackages = buildJavaPackages(path);
         Collection<Bundle> bundles = new BundleParser().analyzeManifests(path);
         Map<String, CtPackage> packageByQName = convertPackagesToMap(javaPackages);
@@ -30,7 +31,7 @@ public class LanguageParser {
             }
             languageComponents.add(new Component(bundlePackage, bundle));
         }
-        return languageComponents;
+        return new ModularLanguage(languageComponents);
     }
 
     private static Collection<CtPackage> buildJavaPackages(String path) {

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/SimulatorParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/SimulatorParser.java
@@ -7,6 +7,7 @@ import edu.kit.kastel.sdq.case4lang.refactorlizar.core.javaparser.ModelBuilder;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser.BundleParser;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.Bundle;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.Component;
+import edu.kit.kastel.sdq.case4lang.refactorlizar.model.SimulatorModel;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,8 +17,9 @@ import spoon.reflect.declaration.CtPackage;
 
 public class SimulatorParser {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    private static ModelBuilder builder;
 
-    public static Set<Component> parseSimulator(String path) {
+    public static SimulatorModel parseSimulator(String path) {
         Collection<CtPackage> javaPackages = buildJavaPackages(path);
         Collection<Bundle> bundles = new BundleParser().analyzeManifests(path);
         Map<String, CtPackage> packageByQName = convertPackagesToMap(javaPackages);
@@ -30,11 +32,12 @@ public class SimulatorParser {
             }
             simulatorComponents.add(new Component(bundlePackage, bundle));
         }
-        return simulatorComponents;
+
+        return new SimulatorModel(simulatorComponents, builder.getLauncher());
     }
 
     private static Collection<CtPackage> buildJavaPackages(String path) {
-        ModelBuilder builder = new ModelBuilder();
+        builder = new ModelBuilder();
         builder.buildModel(path);
         return builder.getAllPackages();
     }

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/javaparser/ModelBuilder.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/javaparser/ModelBuilder.java
@@ -15,10 +15,11 @@ public class ModelBuilder {
 
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
     private CtModel model;
+    private Launcher launcher;
 
     public void buildModel(String path) {
         logger.atInfo().log("start building model for path %s", path);
-        Launcher launcher = new Launcher();
+        launcher = new Launcher();
         Environment env = launcher.getEnvironment();
         env.setComplianceLevel(11);
         env.setOutputType(OutputType.NO_OUTPUT);
@@ -30,6 +31,10 @@ public class ModelBuilder {
         logger.atInfo().log(
                 "finished building model for path %s, with model size: %d, in %d packages",
                 path, model.getAllTypes().size(), model.getAllPackages().size());
+    }
+
+    public Launcher getLauncher() {
+        return launcher;
     }
 
     public Collection<CtType<?>> getAllTypes() {

--- a/dependency-cycle/src/test/java/tests/SimpleTest.java
+++ b/dependency-cycle/src/test/java/tests/SimpleTest.java
@@ -15,11 +15,9 @@ public class SimpleTest {
     @Test
     public void typeLevelReport() {
         ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/xppu/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(
-                        SimulatorParser.parseSimulator("src/test/resources/xppu/simulator"));
+                LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/xppu/simulator");
+
         DependencyCycleAnalyzer dca = new DependencyCycleAnalyzer();
         Settings settings = dca.getSettings();
         settings.setValue("level", "type");
@@ -31,11 +29,9 @@ public class SimpleTest {
     @Test
     public void packageLevelReport() {
         ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/xppu/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(
-                        SimulatorParser.parseSimulator("src/test/resources/xppu/simulator"));
+                LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/xppu/simulator");
+
         DependencyCycleAnalyzer dca = new DependencyCycleAnalyzer();
         Settings settings = dca.getSettings();
         settings.setValue("level", "package");
@@ -47,11 +43,8 @@ public class SimpleTest {
     @Test
     public void componentLevelReport() {
         ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/xppu/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(
-                        SimulatorParser.parseSimulator("src/test/resources/xppu/simulator"));
+                LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/xppu/simulator");
         DependencyCycleAnalyzer dca = new DependencyCycleAnalyzer();
         Settings settings = dca.getSettings();
         settings.setValue("level", "component");

--- a/dependency-direction/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/DependencyDirectionAnalyzerTest.java
+++ b/dependency-direction/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/DependencyDirectionAnalyzerTest.java
@@ -29,11 +29,9 @@ public class DependencyDirectionAnalyzerTest {
              Bar uses an lower layer and breaches the strict layering.
              */
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage("src/test/resources/modular_language"));
+                    LanguageParser.parseLanguage("src/test/resources/modular_language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/wrong_direction"));
+                    SimulatorParser.parseSimulator("src/test/resources/wrong_direction");
             DependencyDirectionAnalyzer dda = new DependencyDirectionAnalyzer();
             Settings settings = dda.getSettings();
             settings.setValue("level", "type");
@@ -57,11 +55,9 @@ public class DependencyDirectionAnalyzerTest {
              ----------
              */
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage("src/test/resources/modular_language"));
+                    LanguageParser.parseLanguage("src/test/resources/modular_language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/correct_direction"));
+                    SimulatorParser.parseSimulator("src/test/resources/correct_direction");
             DependencyDirectionAnalyzer dda = new DependencyDirectionAnalyzer();
             Settings settings = dda.getSettings();
             settings.setValue("level", "type");
@@ -89,11 +85,9 @@ public class DependencyDirectionAnalyzerTest {
              Bar uses an lower layer and breaches the strict layering.
              */
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage("src/test/resources/modular_language"));
+                    LanguageParser.parseLanguage("src/test/resources/modular_language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/wrong_direction"));
+                    SimulatorParser.parseSimulator("src/test/resources/wrong_direction");
             DependencyDirectionAnalyzer dda = new DependencyDirectionAnalyzer();
             Settings settings = dda.getSettings();
             settings.setValue("level", "package");
@@ -117,11 +111,9 @@ public class DependencyDirectionAnalyzerTest {
              ----------
              */
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage("src/test/resources/modular_language"));
+                    LanguageParser.parseLanguage("src/test/resources/modular_language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/correct_direction"));
+                    SimulatorParser.parseSimulator("src/test/resources/correct_direction");
             DependencyDirectionAnalyzer dda = new DependencyDirectionAnalyzer();
             Settings settings = dda.getSettings();
             settings.setValue("level", "package");
@@ -149,11 +141,9 @@ public class DependencyDirectionAnalyzerTest {
              Bar uses an lower layer and breaches the strict layering.
              */
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage("src/test/resources/modular_language"));
+                    LanguageParser.parseLanguage("src/test/resources/modular_language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/wrong_direction"));
+                    SimulatorParser.parseSimulator("src/test/resources/wrong_direction");
             DependencyDirectionAnalyzer dda = new DependencyDirectionAnalyzer();
             Settings settings = dda.getSettings();
             settings.setValue("level", "component");
@@ -177,11 +167,9 @@ public class DependencyDirectionAnalyzerTest {
              ----------
              */
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage("src/test/resources/modular_language"));
+                    LanguageParser.parseLanguage("src/test/resources/modular_language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/correct_direction"));
+                    SimulatorParser.parseSimulator("src/test/resources/correct_direction");
             DependencyDirectionAnalyzer dda = new DependencyDirectionAnalyzer();
             Settings settings = dda.getSettings();
             settings.setValue("level", "component");

--- a/dependency-layer/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/DependencyLayerAnalyzerTest.java
+++ b/dependency-layer/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/DependencyLayerAnalyzerTest.java
@@ -18,12 +18,9 @@ public class DependencyLayerAnalyzerTest {
         @Test
         public void wrong_layer() {
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage(
-                                    "src/test/resources/xppu/modular-language"));
+                    LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/xppu/wrong_layer"));
+                    SimulatorParser.parseSimulator("src/test/resources/xppu/wrong_layer");
             DependencyLayerAnalyzer dla = new DependencyLayerAnalyzer();
             Settings settings = dla.getSettings();
             settings.setValue("level", "type");
@@ -35,13 +32,9 @@ public class DependencyLayerAnalyzerTest {
         @Test
         public void correct_layer() {
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage(
-                                    "src/test/resources/xppu/modular-language"));
+                    LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator(
-                                    "src/test/resources/xppu/correct_layer"));
+                    SimulatorParser.parseSimulator("src/test/resources/xppu/correct_layer");
             DependencyLayerAnalyzer dla = new DependencyLayerAnalyzer();
             Settings settings = dla.getSettings();
             settings.setValue("level", "type");
@@ -56,12 +49,9 @@ public class DependencyLayerAnalyzerTest {
         @Test
         public void wrong_layer() {
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage(
-                                    "src/test/resources/xppu/modular-language"));
+                    LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/xppu/wrong_layer"));
+                    SimulatorParser.parseSimulator("src/test/resources/xppu/wrong_layer");
             DependencyLayerAnalyzer dla = new DependencyLayerAnalyzer();
             Settings settings = dla.getSettings();
             settings.setValue("level", "package");
@@ -73,13 +63,9 @@ public class DependencyLayerAnalyzerTest {
         @Test
         public void correct_layer() {
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage(
-                                    "src/test/resources/xppu/modular-language"));
+                    LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator(
-                                    "src/test/resources/xppu/correct_layer"));
+                    SimulatorParser.parseSimulator("src/test/resources/xppu/correct_layer");
             DependencyLayerAnalyzer dla = new DependencyLayerAnalyzer();
             Settings settings = dla.getSettings();
             settings.setValue("level", "package");
@@ -94,12 +80,9 @@ public class DependencyLayerAnalyzerTest {
         @Test
         public void wrong_layer() {
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage(
-                                    "src/test/resources/xppu/modular-language"));
+                    LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator("src/test/resources/xppu/wrong_layer"));
+                    SimulatorParser.parseSimulator("src/test/resources/xppu/wrong_layer");
             DependencyLayerAnalyzer dla = new DependencyLayerAnalyzer();
             Settings settings = dla.getSettings();
             settings.setValue("level", "component");
@@ -111,13 +94,9 @@ public class DependencyLayerAnalyzerTest {
         @Test
         public void correct_layer() {
             ModularLanguage language =
-                    new ModularLanguage(
-                            LanguageParser.parseLanguage(
-                                    "src/test/resources/xppu/modular-language"));
+                    LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
             SimulatorModel simulator =
-                    new SimulatorModel(
-                            SimulatorParser.parseSimulator(
-                                    "src/test/resources/xppu/correct_layer"));
+                    SimulatorParser.parseSimulator("src/test/resources/xppu/correct_layer");
             DependencyLayerAnalyzer dla = new DependencyLayerAnalyzer();
             Settings settings = dla.getSettings();
             settings.setValue("level", "component");

--- a/feature-scatter/src/test/java/tests/SimpleTest.java
+++ b/feature-scatter/src/test/java/tests/SimpleTest.java
@@ -14,11 +14,8 @@ public class SimpleTest {
 
     @Test
     public void typeLevelReport() {
-        ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(SimulatorParser.parseSimulator("src/test/resources/simulator"));
+        ModularLanguage lang = LanguageParser.parseLanguage("src/test/resources/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/simulator");
         FeatureScatterAnalyzer fca = new FeatureScatterAnalyzer();
         Settings settings = fca.getSettings();
         settings.setValue("level", "type");
@@ -29,11 +26,8 @@ public class SimpleTest {
 
     @Test
     public void packageLevelReport() {
-        ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(SimulatorParser.parseSimulator("src/test/resources/simulator"));
+        ModularLanguage lang = LanguageParser.parseLanguage("src/test/resources/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/simulator");
         FeatureScatterAnalyzer fca = new FeatureScatterAnalyzer();
         Settings settings = fca.getSettings();
         settings.setValue("level", "package");
@@ -44,11 +38,8 @@ public class SimpleTest {
 
     @Test
     public void componentLevelReport() {
-        ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(SimulatorParser.parseSimulator("src/test/resources/simulator"));
+        ModularLanguage lang = LanguageParser.parseLanguage("src/test/resources/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/simulator");
         FeatureScatterAnalyzer fca = new FeatureScatterAnalyzer();
         Settings settings = fca.getSettings();
         settings.setValue("level", "component");

--- a/language-blob/src/test/java/tests/SimpleTest.java
+++ b/language-blob/src/test/java/tests/SimpleTest.java
@@ -15,11 +15,8 @@ class SimpleTest {
     @Test
     void packageLevelReport() {
         ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/xppu/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(
-                        SimulatorParser.parseSimulator("src/test/resources/xppu/simulator"));
+                LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/xppu/simulator");
         LanguageBlobAnalyzer lba = new LanguageBlobAnalyzer();
         Settings settings = lba.getSettings();
         settings.setValue("level", "package");
@@ -31,11 +28,8 @@ class SimpleTest {
     @Test
     void componentLevelReport() {
         ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/xppu/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(
-                        SimulatorParser.parseSimulator("src/test/resources/xppu/simulator"));
+                LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/xppu/simulator");
         LanguageBlobAnalyzer lba = new LanguageBlobAnalyzer();
         Settings settings = lba.getSettings();
         settings.setValue("level", "component");
@@ -47,11 +41,8 @@ class SimpleTest {
     @Test
     void typeLevelReport() {
         ModularLanguage lang =
-                new ModularLanguage(
-                        LanguageParser.parseLanguage("src/test/resources/xppu/modular-language"));
-        SimulatorModel model =
-                new SimulatorModel(
-                        SimulatorParser.parseSimulator("src/test/resources/xppu/simulator"));
+                LanguageParser.parseLanguage("src/test/resources/xppu/modular-language");
+        SimulatorModel model = SimulatorParser.parseSimulator("src/test/resources/xppu/simulator");
         LanguageBlobAnalyzer lba = new LanguageBlobAnalyzer();
         Settings settings = lba.getSettings();
         settings.setValue("level", "type");

--- a/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/SimulatorModel.java
+++ b/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/SimulatorModel.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import spoon.Launcher;
+import spoon.OutputType;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.filter.TypeFilter;
@@ -16,6 +18,7 @@ public class SimulatorModel {
 
     private Set<Component> simulatorComponents;
     private Lookup<String, CtType<?>> typeByQNameLookup;
+    private Launcher launcher;
 
     public <T extends CtElement> Collection<T> getAllElements(Class<? extends T> clazz) {
         return simulatorComponents.stream()
@@ -30,6 +33,16 @@ public class SimulatorModel {
     public SimulatorModel(Set<Component> languageComponents) {
         this.simulatorComponents = languageComponents;
         typeByQNameLookup = createTypeByQNameLookup(languageComponents);
+    }
+
+    public SimulatorModel(Set<Component> languageComponents, Launcher launcher) {
+        this(languageComponents);
+        this.launcher = launcher;
+    }
+
+    public void print(String path) {
+        launcher.getEnvironment().setOutputType(OutputType.CLASSES);
+        launcher.setSourceOutputDirectory(path);
     }
 
     private Lookup<String, CtType<?>> createTypeByQNameLookup(


### PR DESCRIPTION
This PR adds a printing method to the simulator model. This also includes a breaking change in the SimulatorModel- and LanguageModel Parser methods. Instead of a `Set<Component>` it now returns the model directly. This makes the API easier to use and enables the printing.