### PR TITLE
chore(java): add javac flags for jdk16

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,9 @@ modelVersion = 0.0.2
 commonsAnalyzer  = commons-analyzer
 commonsAnalyzerVersion = 0.0.2
 commons = commons
+
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
This PR adds javac flags needed for building on jdk16 and newer.
https://openjdk.java.net/jeps/396 is the cause for this change.