### PR TITLE
feature(generalization): Make the Allen metric usable with alternate source models

### DIFF
--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Application.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Application.java
@@ -10,10 +10,10 @@ import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codeme
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.cohesion.HyperGraphCohesionCalculator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity.HyperGraphComplexityCalculator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.coupling.HyperGraphInterModuleCouplingGenerator;
+import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.CtTypeSystemGraphUtils;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.HyperGraphGenerator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphUtils;
-import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.CtTypeSystemGraphUtils;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.projectfilter.DataTypesFilter;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.projectfilter.ObservedSystemFilter;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.size.HyperGraphSizeCalculator;
@@ -43,13 +43,22 @@ public class Application {
         graph = removeNotObservedSystem(graph, observedSystemPath);
         SystemGraphUtils<CtType<?>> systemGraphUtils = new CtTypeSystemGraphUtils();
         HyperGraphSize size = calculateHyperGraphSize(mode, systemGraphUtils, graph);
-        Complexity graphComplexity = new HyperGraphComplexityCalculator<CtType<?>>(mode, systemGraphUtils).calculate(graph);
-        Coupling graphCoupling = new HyperGraphInterModuleCouplingGenerator<CtType<?>>(mode, systemGraphUtils).calculate(graph);
-        Cohesion cohesion = new HyperGraphCohesionCalculator<CtType<?>>(mode, systemGraphUtils).calculate(graph);
+        Complexity graphComplexity =
+                new HyperGraphComplexityCalculator<CtType<?>>(mode, systemGraphUtils)
+                        .calculate(graph);
+        Coupling graphCoupling =
+                new HyperGraphInterModuleCouplingGenerator<CtType<?>>(mode, systemGraphUtils)
+                        .calculate(graph);
+        Cohesion cohesion =
+                new HyperGraphCohesionCalculator<CtType<?>>(mode, systemGraphUtils)
+                        .calculate(graph);
         return new Result(loc, sos, size, graphComplexity, graphCoupling, cohesion);
     }
 
-    private HyperGraphSize calculateHyperGraphSize(CalculationMode mode, SystemGraphUtils<CtType<?>> systemGraphUtils, Graph<Node<CtType<?>>> graph) {
+    private HyperGraphSize calculateHyperGraphSize(
+            CalculationMode mode,
+            SystemGraphUtils<CtType<?>> systemGraphUtils,
+            Graph<Node<CtType<?>>> graph) {
         return new HyperGraphSize(
                 new HyperGraphSizeCalculator<CtType<?>>(mode)
                         .calculate(systemGraphUtils.convertToSystemGraph(graph)));
@@ -65,7 +74,8 @@ public class Application {
         return model.getAllTypes();
     }
 
-    private Graph<Node<CtType<?>>> removeNotObservedSystem(Graph<Node<CtType<?>>> graph, String observedSystemPath) {
+    private Graph<Node<CtType<?>>> removeNotObservedSystem(
+            Graph<Node<CtType<?>>> graph, String observedSystemPath) {
         if (observedSystemPath.isBlank()) {
             return graph;
         }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Application.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Application.java
@@ -12,7 +12,8 @@ import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.comple
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.coupling.HyperGraphInterModuleCouplingGenerator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.HyperGraphGenerator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
-import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphs;
+import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphUtils;
+import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.CtTypeSystemGraphUtils;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.projectfilter.DataTypesFilter;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.projectfilter.ObservedSystemFilter;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.size.HyperGraphSizeCalculator;
@@ -38,19 +39,20 @@ public class Application {
         removeDataTypes(types, dataPatternsPath);
         LinesOfCode loc = calculateLoC(types);
         SizeOfSystem sos = calculateSizeOfSystem(types);
-        Graph<Node> graph = new HyperGraphGenerator().createHyperGraph(types);
+        Graph<Node<CtType<?>>> graph = new HyperGraphGenerator().createHyperGraph(types);
         graph = removeNotObservedSystem(graph, observedSystemPath);
-        HyperGraphSize size = calculateHyperGraphSize(mode, graph);
-        Complexity graphComplexity = new HyperGraphComplexityCalculator(mode).calculate(graph);
-        Coupling graphCoupling = new HyperGraphInterModuleCouplingGenerator(mode).calculate(graph);
-        Cohesion cohesion = new HyperGraphCohesionCalculator(mode).calculate(graph);
+        SystemGraphUtils<CtType<?>> systemGraphUtils = new CtTypeSystemGraphUtils();
+        HyperGraphSize size = calculateHyperGraphSize(mode, systemGraphUtils, graph);
+        Complexity graphComplexity = new HyperGraphComplexityCalculator<CtType<?>>(mode, systemGraphUtils).calculate(graph);
+        Coupling graphCoupling = new HyperGraphInterModuleCouplingGenerator<CtType<?>>(mode, systemGraphUtils).calculate(graph);
+        Cohesion cohesion = new HyperGraphCohesionCalculator<CtType<?>>(mode, systemGraphUtils).calculate(graph);
         return new Result(loc, sos, size, graphComplexity, graphCoupling, cohesion);
     }
 
-    private HyperGraphSize calculateHyperGraphSize(CalculationMode mode, Graph<Node> graph) {
+    private HyperGraphSize calculateHyperGraphSize(CalculationMode mode, SystemGraphUtils<CtType<?>> systemGraphUtils, Graph<Node<CtType<?>>> graph) {
         return new HyperGraphSize(
-                new HyperGraphSizeCalculator(mode)
-                        .calculate(SystemGraphs.convertToSystemGraph(graph)));
+                new HyperGraphSizeCalculator<CtType<?>>(mode)
+                        .calculate(systemGraphUtils.convertToSystemGraph(graph)));
     }
 
     private Collection<CtType<?>> parseTypes(String... paths) {
@@ -63,7 +65,7 @@ public class Application {
         return model.getAllTypes();
     }
 
-    private Graph<Node> removeNotObservedSystem(Graph<Node> graph, String observedSystemPath) {
+    private Graph<Node<CtType<?>>> removeNotObservedSystem(Graph<Node<CtType<?>>> graph, String observedSystemPath) {
         if (observedSystemPath.isBlank()) {
             return graph;
         }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/cohesion/HyperGraphCohesionCalculator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/cohesion/HyperGraphCohesionCalculator.java
@@ -10,7 +10,6 @@ import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codeme
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity.HyperGraphComplexityCalculator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphUtils;
-
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -18,9 +17,10 @@ import java.util.stream.Collectors;
 public class HyperGraphCohesionCalculator<T> {
 
     private CalculationMode mode;
-	private SystemGraphUtils<T> systemGraphUtils;
+    private SystemGraphUtils<T> systemGraphUtils;
 
-    public HyperGraphCohesionCalculator(CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
+    public HyperGraphCohesionCalculator(
+            CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
         this.mode = Objects.requireNonNull(mode);
         this.systemGraphUtils = systemGraphUtils;
     }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/HyperGraphComplexityCalculator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/HyperGraphComplexityCalculator.java
@@ -14,12 +14,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class HyperGraphComplexityCalculator<T> {
-	
+
     private CalculationMode mode;
-	private SystemGraphUtils<T> systemGraphUtils;
+    private SystemGraphUtils<T> systemGraphUtils;
 
     // die größe eines Graphen wird immer auf dem Systemgraphen berechnet
-    public HyperGraphComplexityCalculator(CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
+    public HyperGraphComplexityCalculator(
+            CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
         this.mode = Objects.requireNonNull(mode);
         this.systemGraphUtils = systemGraphUtils;
     }
@@ -38,12 +39,14 @@ public class HyperGraphComplexityCalculator<T> {
         double subgraphSize = 0.0;
         for (Node<T> executable : hyperEdgeOnlyGraph.nodes()) {
             Graph<Node<T>> subgraph = createSubGraph(hyperEdgeOnlyGraph, executable);
-            subgraphSize += sizeCalculator.calculate(systemGraphUtils.convertToSystemGraph(subgraph));
+            subgraphSize +=
+                    sizeCalculator.calculate(systemGraphUtils.convertToSystemGraph(subgraph));
         }
         return subgraphSize;
     }
 
-    private Graph<Node<T>> createSubGraph(MutableGraph<Node<T>> hyperEdgeOnlyGraph, Node<T> executable) {
+    private Graph<Node<T>> createSubGraph(
+            MutableGraph<Node<T>> hyperEdgeOnlyGraph, Node<T> executable) {
         Set<Node<T>> reachableNodes = new HashSet<>(hyperEdgeOnlyGraph.adjacentNodes(executable));
         reachableNodes.add(executable);
         return Graphs.inducedSubgraph(hyperEdgeOnlyGraph, reachableNodes);

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/HyperGraphComplexityCalculator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/HyperGraphComplexityCalculator.java
@@ -1,66 +1,68 @@
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity;
 
-import static edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphs.convertToSystemGraph;
-
 import com.google.common.graph.Graph;
 import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableGraph;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.CalculationMode;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics.Complexity;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
+import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphUtils;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.size.HyperGraphSizeCalculator;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class HyperGraphComplexityCalculator {
+public class HyperGraphComplexityCalculator<T> {
+	
     private CalculationMode mode;
+	private SystemGraphUtils<T> systemGraphUtils;
 
     // die größe eines Graphen wird immer auf dem Systemgraphen berechnet
-    public HyperGraphComplexityCalculator(CalculationMode mode) {
+    public HyperGraphComplexityCalculator(CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
         this.mode = Objects.requireNonNull(mode);
+        this.systemGraphUtils = systemGraphUtils;
     }
 
-    public Complexity calculate(Graph<Node> hypergraph) {
-        MutableGraph<Node> hyperEdgeOnlyGraph = transformToHyperedgeOnly(hypergraph);
-        HyperGraphSizeCalculator sizeCalculator = new HyperGraphSizeCalculator(mode);
+    public Complexity calculate(Graph<Node<T>> hypergraph) {
+        MutableGraph<Node<T>> hyperEdgeOnlyGraph = transformToHyperedgeOnly(hypergraph);
+        HyperGraphSizeCalculator<T> sizeCalculator = new HyperGraphSizeCalculator<T>(mode);
         double hyperEdgeOnlyGraphSize =
-                sizeCalculator.calculate(convertToSystemGraph(hyperEdgeOnlyGraph));
+                sizeCalculator.calculate(systemGraphUtils.convertToSystemGraph(hyperEdgeOnlyGraph));
         double subgraphSize = calculateSubGraphsSize(hyperEdgeOnlyGraph, sizeCalculator);
         return new Complexity(subgraphSize - hyperEdgeOnlyGraphSize);
     }
 
     private double calculateSubGraphsSize(
-            MutableGraph<Node> hyperEdgeOnlyGraph, HyperGraphSizeCalculator sizeCalculator) {
+            MutableGraph<Node<T>> hyperEdgeOnlyGraph, HyperGraphSizeCalculator<T> sizeCalculator) {
         double subgraphSize = 0.0;
-        for (Node executable : hyperEdgeOnlyGraph.nodes()) {
-            Graph<Node> subgraph = createSubGraph(hyperEdgeOnlyGraph, executable);
-            subgraphSize += sizeCalculator.calculate(convertToSystemGraph(subgraph));
+        for (Node<T> executable : hyperEdgeOnlyGraph.nodes()) {
+            Graph<Node<T>> subgraph = createSubGraph(hyperEdgeOnlyGraph, executable);
+            subgraphSize += sizeCalculator.calculate(systemGraphUtils.convertToSystemGraph(subgraph));
         }
         return subgraphSize;
     }
 
-    private Graph<Node> createSubGraph(MutableGraph<Node> hyperEdgeOnlyGraph, Node executable) {
-        Set<Node> reachableNodes = new HashSet<>(hyperEdgeOnlyGraph.adjacentNodes(executable));
+    private Graph<Node<T>> createSubGraph(MutableGraph<Node<T>> hyperEdgeOnlyGraph, Node<T> executable) {
+        Set<Node<T>> reachableNodes = new HashSet<>(hyperEdgeOnlyGraph.adjacentNodes(executable));
         reachableNodes.add(executable);
         return Graphs.inducedSubgraph(hyperEdgeOnlyGraph, reachableNodes);
     }
 
-    private MutableGraph<Node> transformToHyperedgeOnly(Graph<Node> hypergraph) {
-        MutableGraph<Node> hyperEdgeOnlyGraph = Graphs.copyOf(hypergraph);
+    private MutableGraph<Node<T>> transformToHyperedgeOnly(Graph<Node<T>> hypergraph) {
+        MutableGraph<Node<T>> hyperEdgeOnlyGraph = Graphs.copyOf(hypergraph);
         removeDisconnectedNodes(hyperEdgeOnlyGraph);
         return hyperEdgeOnlyGraph;
     }
 
-    private void removeDisconnectedNodes(MutableGraph<Node> hyperEdgeOnlyGraph) {
+    private void removeDisconnectedNodes(MutableGraph<Node<T>> hyperEdgeOnlyGraph) {
         hyperEdgeOnlyGraph.nodes().stream()
                 .filter(node -> hasZeroDegree(hyperEdgeOnlyGraph, node))
                 .collect(Collectors.toList())
                 .forEach(hyperEdgeOnlyGraph::removeNode);
     }
 
-    private boolean hasZeroDegree(MutableGraph<Node> hyperEdgeOnlyGraph, Node node) {
+    private boolean hasZeroDegree(MutableGraph<Node<T>> hyperEdgeOnlyGraph, Node<T> node) {
         return hyperEdgeOnlyGraph.degree(node) == 0;
     }
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/coupling/HyperGraphInterModuleCouplingGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/coupling/HyperGraphInterModuleCouplingGenerator.java
@@ -9,17 +9,17 @@ import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codeme
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity.HyperGraphComplexityCalculator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphUtils;
-
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class HyperGraphInterModuleCouplingGenerator<T> {
 
     private CalculationMode mode;
-	private SystemGraphUtils<T> systemGraphUtils;
+    private SystemGraphUtils<T> systemGraphUtils;
 
     // die größe eines Graphen wird immer auf dem Systemgraphen berechnet
-    public HyperGraphInterModuleCouplingGenerator(CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
+    public HyperGraphInterModuleCouplingGenerator(
+            CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
         this.mode = Objects.requireNonNull(mode);
         this.systemGraphUtils = systemGraphUtils;
     }
@@ -31,7 +31,9 @@ public class HyperGraphInterModuleCouplingGenerator<T> {
                 .collect(Collectors.toSet())
                 .forEach(interModuleGraph::removeEdge);
         return new Coupling(
-                new HyperGraphComplexityCalculator<T>(mode, systemGraphUtils).calculate(interModuleGraph).getValue());
+                new HyperGraphComplexityCalculator<T>(mode, systemGraphUtils)
+                        .calculate(interModuleGraph)
+                        .getValue());
     }
 
     private boolean hasEndpointsInSameTypes(EndpointPair<Node<T>> edge) {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/coupling/HyperGraphInterModuleCouplingGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/coupling/HyperGraphInterModuleCouplingGenerator.java
@@ -8,38 +8,41 @@ import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.Calcul
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics.Coupling;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity.HyperGraphComplexityCalculator;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
+import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.SystemGraphUtils;
+
 import java.util.Objects;
 import java.util.stream.Collectors;
-import spoon.reflect.declaration.CtType;
 
-public class HyperGraphInterModuleCouplingGenerator {
+public class HyperGraphInterModuleCouplingGenerator<T> {
 
     private CalculationMode mode;
+	private SystemGraphUtils<T> systemGraphUtils;
 
     // die größe eines Graphen wird immer auf dem Systemgraphen berechnet
-    public HyperGraphInterModuleCouplingGenerator(CalculationMode mode) {
+    public HyperGraphInterModuleCouplingGenerator(CalculationMode mode, SystemGraphUtils<T> systemGraphUtils) {
         this.mode = Objects.requireNonNull(mode);
+        this.systemGraphUtils = systemGraphUtils;
     }
 
-    public Coupling calculate(Graph<Node> graph) {
-        MutableGraph<Node> interModuleGraph = Graphs.copyOf(graph);
+    public Coupling calculate(Graph<Node<T>> graph) {
+        MutableGraph<Node<T>> interModuleGraph = Graphs.copyOf(graph);
         graph.edges().stream()
                 .filter(this::hasEndpointsInSameTypes)
                 .collect(Collectors.toSet())
                 .forEach(interModuleGraph::removeEdge);
         return new Coupling(
-                new HyperGraphComplexityCalculator(mode).calculate(interModuleGraph).getValue());
+                new HyperGraphComplexityCalculator<T>(mode, systemGraphUtils).calculate(interModuleGraph).getValue());
     }
 
-    private boolean hasEndpointsInSameTypes(EndpointPair<Node> edge) {
+    private boolean hasEndpointsInSameTypes(EndpointPair<Node<T>> edge) {
         return isSameType(edge.nodeU(), edge.nodeV());
     }
 
-    private boolean isSameType(Node u, Node v) {
+    private boolean isSameType(Node<T> u, Node<T> v) {
         return getType(u).equals(getType(v));
     }
 
-    private CtType<?> getType(Node executable) {
-        return executable.getDeclaringType();
+    private T getType(Node<T> executable) {
+        return executable.getModule();
     }
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/CtTypeSystemGraphUtils.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/CtTypeSystemGraphUtils.java
@@ -6,17 +6,17 @@ import com.google.common.graph.MutableGraph;
 import spoon.Launcher;
 import spoon.reflect.declaration.CtType;
 
-public class SystemGraphs {
+public class CtTypeSystemGraphUtils implements SystemGraphUtils<CtType<?>> {
 
-    private SystemGraphs() {}
+    public CtTypeSystemGraphUtils() {}
 
-    public static MutableGraph<Node> convertToSystemGraph(Graph<Node> graph) {
-        MutableGraph<Node> systemGraph = Graphs.copyOf(graph);
+    public MutableGraph<Node<CtType<?>>> convertToSystemGraph(Graph<Node<CtType<?>>> graph) {
+        MutableGraph<Node<CtType<?>>> systemGraph = Graphs.copyOf(graph);
         // add empty node as system node
         CtType<?> type = Launcher.parseClass("class ThIsIsRiskant {}");
         var method = new Launcher().createFactory().createMethod();
         type.addMethod(method);
-        systemGraph.addNode(new Node(method));
+        systemGraph.addNode(new SpoonNode(method));
         return systemGraph;
     }
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/CtTypeSystemGraphUtils.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/CtTypeSystemGraphUtils.java
@@ -10,6 +10,7 @@ public class CtTypeSystemGraphUtils implements SystemGraphUtils<CtType<?>> {
 
     public CtTypeSystemGraphUtils() {}
 
+    @Override
     public MutableGraph<Node<CtType<?>>> convertToSystemGraph(Graph<Node<CtType<?>>> graph) {
         MutableGraph<Node<CtType<?>>> systemGraph = Graphs.copyOf(graph);
         // add empty node as system node

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGenerator.java
@@ -19,23 +19,23 @@ import spoon.support.reflect.declaration.CtConstructorImpl;
 
 public class HyperGraphGenerator {
 
-    public MutableGraph<Node> createHyperGraph(Collection<CtType<?>> types) {
-        MutableGraph<Node> graph = createGraph();
+    public MutableGraph<Node<CtType<?>>> createHyperGraph(Collection<CtType<?>> types) {
+        MutableGraph<Node<CtType<?>>> graph = createGraph();
 
         for (CtType<?> type : types) {
             for (CtTypeMember executable : getMethodsAndConstructorAndFields(type)) {
-                graph.addNode(new Node(executable));
+                graph.addNode(new SpoonNode(executable));
                 getReferencedMembers(executable)
                         .forEach(
                                 calledMethod ->
                                         graph.putEdge(
-                                                new Node(calledMethod), new Node(executable)));
+                                                new SpoonNode(calledMethod), new SpoonNode(executable)));
             }
         }
         return graph;
     }
 
-    private MutableGraph<Node> createGraph() {
+    private MutableGraph<Node<CtType<?>>> createGraph() {
         return GraphBuilder.undirected().allowsSelfLoops(true).build();
     }
 

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGenerator.java
@@ -29,7 +29,8 @@ public class HyperGraphGenerator {
                         .forEach(
                                 calledMethod ->
                                         graph.putEdge(
-                                                new SpoonNode(calledMethod), new SpoonNode(executable)));
+                                                new SpoonNode(calledMethod),
+                                                new SpoonNode(executable)));
             }
         }
         return graph;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
@@ -1,53 +1,13 @@
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
-import java.util.Objects;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeMember;
-import spoon.reflect.visitor.CtVisitor;
+/**
+ * 
+ * @author Reiner Jung
+ *
+ * @param <T> module identifying type
+ */
+public interface Node<T> {
 
-public class Node {
-    private final CtTypeMember member;
+	T getModule();
 
-    /** @param member */
-    public Node(CtTypeMember member) {
-        this.member = member;
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(member, member.getDeclaringType());
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof Node)) return false;
-        Node other = (Node) obj;
-        return Objects.equals(member, other.member)
-                && Objects.equals(member.getDeclaringType(), other.member.getDeclaringType());
-    }
-
-    /**
-     * @param arg0
-     * @see spoon.reflect.visitor.CtVisitable#accept(spoon.reflect.visitor.CtVisitor)
-     */
-    public void accept(CtVisitor arg0) {
-        member.accept(arg0);
-    }
-
-    /**
-     * @return
-     * @see spoon.reflect.declaration.CtTypeMember#getDeclaringType()
-     */
-    public CtType<?> getDeclaringType() {
-        return member.getDeclaringType();
-    }
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
@@ -1,13 +1,10 @@
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 /**
- * 
  * @author Reiner Jung
- *
  * @param <T> module identifying type
  */
 public interface Node<T> {
 
-	T getModule();
-
+    T getModule();
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
@@ -1,10 +1,18 @@
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 /**
+ * Generic interface for all node types. This is mainly a marker interface, but also supports the
+ * joint module identifier method.
+ *
  * @author Reiner Jung
  * @param <T> module identifying type
  */
 public interface Node<T> {
 
+    /**
+     * Provides the associated module for a node.
+     *
+     * @return returns the module to the node
+     */
     T getModule();
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SpoonNode.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SpoonNode.java
@@ -1,0 +1,53 @@
+package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
+
+import java.util.Objects;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.visitor.CtVisitor;
+
+public class SpoonNode implements Node<CtType<?>> {
+    private final CtTypeMember member;
+
+    /** @param member */
+    public SpoonNode(CtTypeMember member) {
+        this.member = member;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(member, member.getDeclaringType());
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof SpoonNode)) return false;
+        SpoonNode other = (SpoonNode) obj;
+        return Objects.equals(member, other.member)
+                && Objects.equals(member.getDeclaringType(), other.member.getDeclaringType());
+    }
+
+    /**
+     * @param arg0
+     * @see spoon.reflect.visitor.CtVisitable#accept(spoon.reflect.visitor.CtVisitor)
+     */
+    public void accept(CtVisitor arg0) {
+        member.accept(arg0);
+    }
+
+    /**
+     * @return
+     * @see spoon.reflect.declaration.CtTypeMember#getDeclaringType()
+     */
+    public CtType<?> getModule() {
+        return member.getDeclaringType();
+    }
+}

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SpoonNode.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SpoonNode.java
@@ -8,7 +8,11 @@ import spoon.reflect.visitor.CtVisitor;
 public class SpoonNode implements Node<CtType<?>> {
     private final CtTypeMember member;
 
-    /** @param member */
+    /**
+     * Create a Node usable with the spoon source model.
+     *
+     * @param member source model member corresponding to the node
+     */
     public SpoonNode(CtTypeMember member) {
         this.member = member;
     }
@@ -16,7 +20,6 @@ public class SpoonNode implements Node<CtType<?>> {
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
-
     @Override
     public int hashCode() {
         return Objects.hash(member, member.getDeclaringType());
@@ -25,7 +28,6 @@ public class SpoonNode implements Node<CtType<?>> {
     /* (non-Javadoc)
      * @see java.lang.Object#equals(java.lang.Object)
      */
-
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -36,7 +38,9 @@ public class SpoonNode implements Node<CtType<?>> {
     }
 
     /**
-     * @param arg0
+     * Allow to set a visitor. This comment needs to be improved.
+     *
+     * @param arg0 the visitor.
      * @see spoon.reflect.visitor.CtVisitable#accept(spoon.reflect.visitor.CtVisitor)
      */
     public void accept(CtVisitor arg0) {
@@ -44,9 +48,12 @@ public class SpoonNode implements Node<CtType<?>> {
     }
 
     /**
-     * @return
+     * Provide the module identifier for the node.
+     *
+     * @return returns a CtType representing the module
      * @see spoon.reflect.declaration.CtTypeMember#getDeclaringType()
      */
+    @Override
     public CtType<?> getModule() {
         return member.getDeclaringType();
     }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
@@ -1,16 +1,11 @@
-/**
- * 
- */
+/** */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 import com.google.common.graph.Graph;
 import com.google.common.graph.MutableGraph;
 
-/**
- * @author Reiner Jung
- *
- */
+/** @author Reiner Jung */
 public interface SystemGraphUtils<T> {
-	
-	public MutableGraph<Node<T>> convertToSystemGraph(Graph<Node<T>> graph);
+
+    public MutableGraph<Node<T>> convertToSystemGraph(Graph<Node<T>> graph);
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
@@ -4,8 +4,20 @@ package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graph
 import com.google.common.graph.Graph;
 import com.google.common.graph.MutableGraph;
 
-/** @author Reiner Jung */
+/**
+ * Common interface of graph to system graph converters. As a system graph adds a special node to
+ * the graph for the environment, it must adhere to the used node implementation for the graph.
+ * Thus, there must be one for each node type.
+ *
+ * @author Reiner Jung
+ */
 public interface SystemGraphUtils<T> {
 
+    /**
+     * Graph to system graph converter method.
+     *
+     * @param graph the input graph
+     * @return returns a system graph for the given input graph
+     */
     public MutableGraph<Node<T>> convertToSystemGraph(Graph<Node<T>> graph);
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
@@ -1,0 +1,16 @@
+/**
+ * 
+ */
+package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
+
+import com.google.common.graph.Graph;
+import com.google.common.graph.MutableGraph;
+
+/**
+ * @author Reiner Jung
+ *
+ */
+public interface SystemGraphUtils<T> {
+	
+	public MutableGraph<Node<T>> convertToSystemGraph(Graph<Node<T>> graph);
+}

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilter.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilter.java
@@ -4,6 +4,8 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Graphs;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
+import spoon.reflect.declaration.CtType;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,8 +20,8 @@ public class ObservedSystemFilter {
 
     private ObservedSystemFilter() {}
 
-    public static Graph<Node> removeNonObservedSystem(
-            Graph<Node> graph, String observedSystemPath) {
+    public static Graph<Node<CtType<?>>> removeNonObservedSystem(
+            Graph<Node<CtType<?>>> graph, String observedSystemPath) {
         var result = Graphs.copyOf(graph);
         try (Stream<String> lines = Files.lines(Path.of(observedSystemPath))) {
             Predicate<String> pattern =
@@ -35,19 +37,19 @@ public class ObservedSystemFilter {
         return graph;
     }
 
-    private static List<Node> filterNonObservedNodes(
-            Graph<Node> result, Predicate<String> pattern) {
+    private static List<Node<CtType<?>>> filterNonObservedNodes(
+            Graph<Node<CtType<?>>> result, Predicate<String> pattern) {
         return result.nodes().stream()
                 .filter(ObservedSystemFilter::hasDeclaringType)
                 .filter(v -> pattern.negate().test(getQualifiedName(v)))
                 .collect(Collectors.toList());
     }
 
-    private static boolean hasDeclaringType(Node v) {
-        return v.getDeclaringType() != null;
+    private static <T> boolean hasDeclaringType(Node<T> v) {
+        return v.getModule() != null;
     }
 
-    private static String getQualifiedName(Node v) {
-        return v.getDeclaringType().getQualifiedName();
+    private static String getQualifiedName(Node<CtType<?>> v) {
+        return v.getModule().getQualifiedName();
     }
 }

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilter.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilter.java
@@ -4,8 +4,6 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Graphs;
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs.Node;
-import spoon.reflect.declaration.CtType;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,6 +12,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import spoon.reflect.declaration.CtType;
 
 public class ObservedSystemFilter {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/HyperGraphSizeCalculator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/HyperGraphSizeCalculator.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class HyperGraphSizeCalculator {
+public class HyperGraphSizeCalculator<T> {
 
     private CalculationMode mode;
 
@@ -21,7 +21,7 @@ public class HyperGraphSizeCalculator {
         this.mode = mode;
     }
 
-    public double calculate(Graph<Node> systemGraph) {
+    public double calculate(Graph<Node<T>> systemGraph) {
         /*
         Schau für jeden Knoten an zu welcher HyperEdge er verbunden ist.
         Das gibt ein Pattern.
@@ -31,9 +31,9 @@ public class HyperGraphSizeCalculator {
         das alles summieren.
         */
         Map<BitSet, Integer> patterns = new HashMap<>();
-        PatternGenerator generator = new PatternGenerator();
-        Set<Node> nodes = systemGraph.nodes();
-        for (Node node : nodes) {
+        PatternGenerator<T> generator = new PatternGenerator<>();
+        Set<Node<T>> nodes = systemGraph.nodes();
+        for (Node<T> node : nodes) {
             BitSet pattern = generator.createPattern(new ArrayList<>(systemGraph.edges()), node);
             if (patterns.get(pattern) == null) {
                 patterns.put(pattern, 1);
@@ -42,7 +42,7 @@ public class HyperGraphSizeCalculator {
             }
         }
         double size = 0;
-        for (Node node : nodes) {
+        for (Node<T> node : nodes) {
             BitSet pattern = generator.createPattern(new ArrayList<>(systemGraph.edges()), node);
             double prob = patterns.get(pattern);
             size += log2(prob / getSystemSize(nodes));
@@ -50,7 +50,7 @@ public class HyperGraphSizeCalculator {
         return size;
     }
 
-    private int getSystemSize(Set<Node> nodes) {
+    private int getSystemSize(Set<Node<T>> nodes) {
         return mode == CalculationMode.REINER ? nodes.size() + 1 : nodes.size();
     }
 

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/PatternGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/PatternGenerator.java
@@ -7,15 +7,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class PatternGenerator {
+public class PatternGenerator<T> {
 
-    private Map<Node, BitSet> cache;
+    private Map<Node<T>, BitSet> cache;
 
     public PatternGenerator() {
         cache = new HashMap<>();
     }
 
-    public BitSet createPattern(List<EndpointPair<Node>> hyperEdges, Node node) {
+    public BitSet createPattern(List<EndpointPair<Node<T>>> hyperEdges, Node<T> node) {
         if (cache.containsKey(node)) {
             return cache.get(node);
         }
@@ -29,7 +29,7 @@ public class PatternGenerator {
         return pattern;
     }
 
-    private boolean isPart(EndpointPair<Node> hyperEdge, Node node) {
+    private boolean isPart(EndpointPair<Node<T>> hyperEdge, Node<T> node) {
         return hyperEdge.nodeU().equals(node) || hyperEdge.nodeV().equals(node);
     }
 }

--- a/architecture-evaluation/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGeneratorTest.java
+++ b/architecture-evaluation/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGeneratorTest.java
@@ -5,13 +5,14 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.graph.Graph;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.declaration.CtType;
 
 public class HyperGraphGeneratorTest {
     @Test
     void testCreateHyperGraph() {
         Launcher launcher = new Launcher();
         launcher.addInputResource("src/test/resources/FieldTest");
-        Graph<Node> g =
+        Graph<Node<CtType<?>>> g =
                 new HyperGraphGenerator().createHyperGraph(launcher.buildModel().getAllTypes());
         g.nodes().forEach(System.out::println);
         assertThat(g.nodes().size()).isEqualTo(7);

--- a/architecture-evaluation/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilterTest.java
+++ b/architecture-evaluation/src/test/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilterTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
+import spoon.reflect.declaration.CtType;
 
 public class ObservedSystemFilterTest {
 
@@ -19,7 +20,7 @@ public class ObservedSystemFilterTest {
     void testRemoveNonObservedSystem() throws IOException {
         Launcher launcher = new Launcher();
         launcher.addInputResource("src/test/resources/FieldTest");
-        Graph<Node> g =
+        Graph<Node<CtType<?>>> g =
                 new HyperGraphGenerator().createHyperGraph(launcher.buildModel().getAllTypes());
         final Path tempFile = Files.createFile(tempDir.resolve("file"));
         Files.writeString(tempFile, ".*");
@@ -34,7 +35,7 @@ public class ObservedSystemFilterTest {
     void testRemoveNonObservedSystem2() throws IOException {
         Launcher launcher = new Launcher();
         launcher.addInputResource("src/test/resources/FieldTest");
-        Graph<Node> g =
+        Graph<Node<CtType<?>>> g =
                 new HyperGraphGenerator().createHyperGraph(launcher.buildModel().getAllTypes());
         final Path tempFile = Files.createFile(tempDir.resolve("file"));
         Files.writeString(tempFile, ".*A.*");


### PR DESCRIPTION
Introduced minor changes to allow to use different Node implementations. Node is now an interface. This allows to use different Node implementation with the metric to allow the use of different source models for the graph. 