### PR TITLE
chore(CI): remove unused token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,5 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
     - uses: actions/checkout@v2
-      with:
-          token: ${{ secrets.ACCESS_TOKEN }}
-          submodules: true
     - name: Test with gradle
       run: ./gradlew build -x spotlessCheck -x test


### PR DESCRIPTION
Currently, the token is no longer needed and stops PRs, from forks.