### PR TITLE
chore(license): enable spotless function to add license to every file

### DIFF
--- a/LicenseHeaderFile.java
+++ b/LicenseHeaderFile.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */

--- a/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/AbstractAnalyzer.java
+++ b/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/AbstractAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.commons.Settings;

--- a/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/ElementVisitor.java
+++ b/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/ElementVisitor.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api;
 
 import java.lang.annotation.Annotation;

--- a/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/IAnalyzer.java
+++ b/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/IAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.commons.Settings;

--- a/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/Report.java
+++ b/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/Report.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api;
 
 import java.util.Collection;

--- a/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/SearchLevels.java
+++ b/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/SearchLevels.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api;
 
 import java.util.Arrays;

--- a/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/Solution.java
+++ b/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/Solution.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api;
 
 public interface Solution {

--- a/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/UnsupportedAnalysisReport.java
+++ b/analyzer-api/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/api/UnsupportedAnalysisReport.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api;
 
 public class UnsupportedAnalysisReport extends Report {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Api.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Api.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation;
 /**
  * A method or class marked with {@code @Api} is part of the public api. These can be considered as

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Application.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Application.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation;
 
 import com.google.common.graph.Graph;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/CalculationMode.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/CalculationMode.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation;
 
 import com.google.common.annotations.Beta;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Paragraph.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Paragraph.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation;
 
 import java.lang.annotation.Retention;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Result.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/Result.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics.Cohesion;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/CodeMetric.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/CodeMetric.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public abstract class CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/Cohesion.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/Cohesion.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public class Cohesion extends CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/Complexity.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/Complexity.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public class Complexity extends CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/Coupling.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/Coupling.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public class Coupling extends CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/HyperGraphSize.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/HyperGraphSize.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public class HyperGraphSize extends CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/InterModuleCoupling.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/InterModuleCoupling.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public class InterModuleCoupling extends CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/LinesOfCode.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/LinesOfCode.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public class LinesOfCode extends CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/SizeOfSystem.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/codemetrics/SizeOfSystem.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.codemetrics;
 
 public class SizeOfSystem extends CodeMetric {

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/cohesion/HyperGraphCohesionCalculator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/cohesion/HyperGraphCohesionCalculator.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.cohesion;
 
 import com.google.common.collect.Sets;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/CyclomaticComplexityCalculation.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/CyclomaticComplexityCalculation.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity;
 
 import java.util.ArrayList;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/CyclomaticComplexityVisitor.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/CyclomaticComplexityVisitor.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity;
 
 import spoon.reflect.code.BinaryOperatorKind;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/HyperGraphComplexityCalculator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/complexity/HyperGraphComplexityCalculator.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.complexity;
 
 import com.google.common.graph.Graph;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/coupling/HyperGraphInterModuleCouplingGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/coupling/HyperGraphInterModuleCouplingGenerator.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.coupling;
 
 import com.google.common.graph.EndpointPair;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/CtTypeSystemGraphUtils.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/CtTypeSystemGraphUtils.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 import com.google.common.graph.Graph;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/HyperGraphGenerator.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 import com.google.common.graph.GraphBuilder;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/Node.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 /**

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SpoonNode.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SpoonNode.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 import java.util.Objects;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/graphs/SystemGraphUtils.java
@@ -1,4 +1,23 @@
-/** */
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.graphs;
 
 import com.google.common.graph.Graph;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/DataTypesFilter.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/DataTypesFilter.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.projectfilter;
 
 import com.google.common.flogger.FluentLogger;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilter.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/projectfilter/ObservedSystemFilter.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.projectfilter;
 
 import com.google.common.flogger.FluentLogger;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/HyperGraphSizeCalculator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/HyperGraphSizeCalculator.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.size;
 
 import com.google.common.graph.Graph;

--- a/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/PatternGenerator.java
+++ b/architecture-evaluation/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/architecture_evaluation/size/PatternGenerator.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.architecture_evaluation.size;
 
 import com.google.common.graph.EndpointPair;

--- a/build.gradle
+++ b/build.gradle
@@ -39,19 +39,29 @@ publishing {
 }
 allprojects {
 	apply plugin: 'com.diffplug.spotless'
-}
-spotless {
-	java {
-		target "**/*.java"
-		targetExclude "**/test/resources/**", "**/build/**"
-		trimTrailingWhitespace()
-		removeUnusedImports()
-		googleJavaFormat().aosp()
-	}
-	groovy {
-		target "**/*.gradle"
-		// Use the default version and Groovy-Eclipse default configuration
-		greclipse()
+	spotless {
+		java {
+			ratchetFrom 'origin/master'
+			target "src/main/java/**/*.java"
+			targetExclude "**/test/resources/**", "**/build/**", "**/LicenseHeaderFile.java"
+			trimTrailingWhitespace()
+			removeUnusedImports()
+			googleJavaFormat().aosp()
+			licenseHeaderFile("$rootProject.projectDir/LicenseHeaderFile.java")
+		}
+		format "javaTestCode", com.diffplug.gradle.spotless.JavaExtension, {
+			ratchetFrom 'origin/master'
+			target "src/test/java/**/*.java"
+			targetExclude "**/test/resources/**", "**/build/**", "**/LicenseHeaderFile.java"
+			trimTrailingWhitespace()
+			removeUnusedImports()
+			googleJavaFormat().aosp()
+		}
+		groovy {
+			target "**/*.gradle"
+			// Use the default version and Groovy-Eclipse default configuration
+			greclipse()
+		}
 	}
 }
 

--- a/class-split/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/refactoring/class_split/ClassSplitBuilder.java
+++ b/class-split/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/refactoring/class_split/ClassSplitBuilder.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.refactoring.class_split;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.commons.refactoring.Refactoring;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/Components.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/Components.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.Component;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/DependencyGraphSupplier.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/DependencyGraphSupplier.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer;
 
 import com.google.common.flogger.FluentLogger;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/Edge.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/Edge.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer;
 
 import java.util.Objects;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/JavaUtils.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/JavaUtils.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.Component;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/Relation.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/Relation.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer;
 
 import java.util.Collection;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/algorithm/CycleDetection.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/algorithm/CycleDetection.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer.algorithm;
 
 import com.google.common.collect.AbstractIterator;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/graphs/ComponentGraphs.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/graphs/ComponentGraphs.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer.graphs;
 
 import com.google.common.graph.MutableNetwork;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/graphs/PackageGraphs.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/graphs/PackageGraphs.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer.graphs;
 
 import com.google.common.graph.MutableNetwork;

--- a/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/graphs/TypeGraphs.java
+++ b/commons-analyzer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons_analyzer/graphs/TypeGraphs.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons_analyzer.graphs;
 
 import com.google.common.graph.MutableNetwork;

--- a/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/Refactoring.java
+++ b/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/Refactoring.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons.refactoring;
 
 @FunctionalInterface

--- a/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/creation/TypeCreation.java
+++ b/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/creation/TypeCreation.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons.refactoring.creation;
 
 import spoon.reflect.declaration.CtClass;

--- a/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/modification/Relations.java
+++ b/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/modification/Relations.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons.refactoring.modification;
 
 import spoon.reflect.declaration.CtClass;

--- a/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/movement/MoveMember.java
+++ b/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/movement/MoveMember.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons.refactoring.movement;
 
 import spoon.reflect.declaration.CtType;

--- a/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/movement/MoveType.java
+++ b/commons-refactoring/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/refactoring/movement/MoveType.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons.refactoring.movement;
 
 import spoon.reflect.declaration.CtPackage;

--- a/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/AbstractSelfRefreshingLookup.java
+++ b/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/AbstractSelfRefreshingLookup.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons;
 
 import java.util.HashMap;

--- a/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/Lookup.java
+++ b/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/Lookup.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons;
 /**
  * This defines a lookup, which gets a value for a given or null if the key is absent.

--- a/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/MutableSettingsEntry.java
+++ b/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/MutableSettingsEntry.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons;
 
 public class MutableSettingsEntry implements SettingsEntry {

--- a/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/SelfRefreshingLookup.java
+++ b/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/SelfRefreshingLookup.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons;
 
 public interface SelfRefreshingLookup<T, U> extends Lookup<T, U> {

--- a/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/SelfRefreshingLookupBuilder.java
+++ b/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/SelfRefreshingLookupBuilder.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons;
 
 import java.util.Map;

--- a/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/Settings.java
+++ b/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/Settings.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons;
 
 import com.google.common.flogger.FluentLogger;

--- a/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/SettingsEntry.java
+++ b/commons/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/commons/SettingsEntry.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.commons;
 /**
  * This defines an immutable settingsentry. An settingsentry is a value with 2 flags, mandatory and

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/InputKind.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/InputKind.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core;
 
 public enum InputKind {

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/LanguageParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/LanguageParser.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core;
 
 import static java.util.stream.Collectors.toMap;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/PathSplitter.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/PathSplitter.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core;
 
 import com.google.common.flogger.FluentLogger;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/RefactorLizar.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/RefactorLizar.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api.IAnalyzer;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/SimulatorParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/SimulatorParser.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core;
 
 import static java.util.stream.Collectors.toMap;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/javaparser/ModelBuilder.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/javaparser/ModelBuilder.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.javaparser;
 
 import com.google.common.flogger.FluentLogger;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/EmfFile.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/EmfFile.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.IMetaInformation;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/EmfFileParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/EmfFileParser.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser;
 
 import com.google.common.flogger.FluentLogger;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/FeatureFile.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/FeatureFile.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.IMetaInformation;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/FeatureFileParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/FeatureFileParser.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser;
 
 import com.google.common.flogger.FluentLogger;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/IMetaInformationParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/IMetaInformationParser.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.IMetaInformation;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/InputReader.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/InputReader.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser;
 
 import com.google.common.collect.Lists;

--- a/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/MetaInformationParser.java
+++ b/core/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/core/pluginparser/MetaInformationParser.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.core.pluginparser;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.model.IMetaInformation;

--- a/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/ComponentLevelReportGeneration.java
+++ b/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/ComponentLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencycycle;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api.Report;

--- a/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/DependencyCycleAnalyzer.java
+++ b/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/DependencyCycleAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencycycle;
 
 import com.google.auto.service.AutoService;

--- a/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/LevelAnalyzer.java
+++ b/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/LevelAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencycycle;
 
 import com.google.common.graph.Graph;

--- a/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/PackageLevelReportGeneration.java
+++ b/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/PackageLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencycycle;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api.Report;

--- a/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/TypeLevelReportGeneration.java
+++ b/dependency-cycle/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencycycle/TypeLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencycycle;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api.Report;

--- a/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/ComponentLevelReportGeneration.java
+++ b/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/ComponentLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencydirection;
 
 import com.google.common.graph.MutableNetwork;

--- a/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/DependencyDirectionAnalyzer.java
+++ b/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/DependencyDirectionAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencydirection;
 
 import com.google.common.base.Splitter;

--- a/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/LevelAnalyzer.java
+++ b/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/LevelAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencydirection;
 
 import com.google.common.flogger.FluentLogger;

--- a/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/PackageLevelReportGeneration.java
+++ b/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/PackageLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencydirection;
 
 import com.google.common.graph.MutableNetwork;

--- a/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/TypeLevelReportGeneration.java
+++ b/dependency-direction/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencydirection/TypeLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencydirection;
 
 import com.google.common.graph.MutableNetwork;

--- a/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/ComponentLevelReportGeneration.java
+++ b/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/ComponentLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencylayer;
 
 import com.google.common.graph.MutableNetwork;

--- a/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/DependencyLayerAnalyzer.java
+++ b/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/DependencyLayerAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencylayer;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.api.AbstractAnalyzer;

--- a/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/LevelAnalyzer.java
+++ b/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/LevelAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencylayer;
 
 import com.google.common.graph.MutableNetwork;

--- a/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/PackageLevelReportGeneration.java
+++ b/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/PackageLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencylayer;
 
 import com.google.common.graph.MutableNetwork;

--- a/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/TypeLevelReportGeneration.java
+++ b/dependency-layer/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/dependencylayer/TypeLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.dependencylayer;
 
 import com.google.common.graph.MutableNetwork;

--- a/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/ComponentLevelReportGeneration.java
+++ b/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/ComponentLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.featurescatter;
 
 import static java.lang.String.format;

--- a/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/FeatureScatterAnalyzer.java
+++ b/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/FeatureScatterAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.featurescatter;
 
 import com.google.auto.service.AutoService;

--- a/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/LevelAnalyzer.java
+++ b/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/LevelAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.featurescatter;
 
 import com.google.common.graph.MutableNetwork;

--- a/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/PackageLevelReportGeneration.java
+++ b/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/PackageLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.featurescatter;
 
 import static java.lang.String.format;

--- a/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/TypeLevelReportGeneration.java
+++ b/feature-scatter/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/featurescatter/TypeLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.featurescatter;
 
 import static java.lang.String.format;

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,12 @@ commonsAnalyzerVersion = 0.0.2
 commons = commons
 
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \ 
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \

--- a/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/ComponentLevelReportGeneration.java
+++ b/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/ComponentLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.languageblob;
 
 import static java.lang.String.format;

--- a/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/LanguageBlobAnalyzer.java
+++ b/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/LanguageBlobAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.languageblob;
 
 import com.google.auto.service.AutoService;

--- a/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/LevelAnalyzer.java
+++ b/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/LevelAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.languageblob;
 
 import com.google.common.graph.MutableNetwork;

--- a/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/PackageLevelReportGeneration.java
+++ b/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/PackageLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.languageblob;
 
 import static java.lang.String.format;

--- a/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/TypeLevelReportGeneration.java
+++ b/language-blob/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/analyzer/languageblob/TypeLevelReportGeneration.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.analyzer.languageblob;
 
 import static java.lang.String.format;

--- a/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/Component.java
+++ b/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/Component.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.model;
 
 import java.util.Objects;

--- a/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/IMetaInformation.java
+++ b/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/IMetaInformation.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.model;
 
 import java.nio.file.Path;

--- a/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/ModularLanguage.java
+++ b/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/ModularLanguage.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.model;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.commons.Lookup;

--- a/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/SimulatorModel.java
+++ b/model/src/main/java/edu/kit/kastel/sdq/case4lang/refactorlizar/model/SimulatorModel.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright (c) 2021 DSiS – Dependability of Software-intensive Systems
+ *
+ * <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * <p>The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
 package edu.kit.kastel.sdq.case4lang.refactorlizar.model;
 
 import edu.kit.kastel.sdq.case4lang.refactorlizar.commons.Lookup;


### PR DESCRIPTION
This PR adds license headers in every src not test file. We use 