### PR TITLE
chore(jitpack): enforce jdk 11 toolchain because of jep396 flag problems in tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,15 @@ spotless {
 		// Use the default version and Groovy-Eclipse default configuration
 		greclipse()
 	}
+	allprojects {
+		afterEvaluate { project ->
+			project.tasks.withType(JavaCompile) {
+				options.compilerArgs.removeAll { it.startsWith("--add") }
+			}
+		}
+	}
 }
+
 
 dependencies {
 	implementation project(":model")

--- a/build.gradle
+++ b/build.gradle
@@ -53,13 +53,6 @@ spotless {
 		// Use the default version and Groovy-Eclipse default configuration
 		greclipse()
 	}
-	allprojects {
-		afterEvaluate { project ->
-			project.tasks.withType(JavaCompile) {
-				options.compilerArgs.removeAll { it.startsWith("--add") }
-			}
-		}
-	}
 }
 
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,6 +12,6 @@ repositories {
 	gradlePluginPortal()
 }
 dependencies {
-	implementation "com.github.jengelman.gradle.plugins:shadow:6.1.0"
-	implementation group: 'net.ltgt.errorprone', name: 'net.ltgt.errorprone.gradle.plugin', version: '1.3.0'
+	implementation group: 'com.github.johnrengelman.shadow', name: 'com.github.johnrengelman.shadow.gradle.plugin', version: '7.0.0'
+	implementation group: 'net.ltgt.errorprone', name: 'net.ltgt.errorprone.gradle.plugin', version: '2.0.2'
 }

--- a/buildSrc/src/main/groovy/edu.kit.kastel.sdq.case4lang.refactorlizar.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/edu.kit.kastel.sdq.case4lang.refactorlizar.java-conventions.gradle
@@ -52,6 +52,11 @@ publishing {
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
 test {
 	useJUnitPlatform()
 }

--- a/buildSrc/src/main/groovy/edu.kit.kastel.sdq.case4lang.refactorlizar.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/edu.kit.kastel.sdq.case4lang.refactorlizar.java-conventions.gradle
@@ -52,9 +52,9 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-    }
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(11)
+	}
 }
 test {
 	useJUnitPlatform()

--- a/buildSrc/src/main/groovy/edu.kit.kastel.sdq.case4lang.refactorlizar.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/edu.kit.kastel.sdq.case4lang.refactorlizar.java-conventions.gradle
@@ -30,7 +30,6 @@ dependencies {
 
 group = 'edu.kit.kastel.sdq.case4lang.refactorlizar'
 version = '0.0.2'
-java.sourceCompatibility = JavaVersion.VERSION_11
 
 distributions {
 	main {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ modelVersion = 0.0.2
 commonsAnalyzer  = commons-analyzer
 commonsAnalyzerVersion = 0.0.2
 commons = commons
-
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,3 @@ modelVersion = 0.0.2
 commonsAnalyzer  = commons-analyzer
 commonsAnalyzerVersion = 0.0.2
 commons = commons
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
A lot of tools like jitpack have currently problems with the needed flags. Because jitpack is only a temporary solution till we move to central, we simply enforce jdk11 toolchain. 